### PR TITLE
content bugfix (typo): Water Bug (wrong: Waterbug) in a fleet definition

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -706,7 +706,7 @@ fleet "Large Human Merchants (Hai)"
 		"Hauler II" 2
 		"Water Bug"
 	variant 1
-		"Waterbug" 2
+		"Water Bug" 2
 		"Firebird (Hai Weapons)" 1
 	variant 3
 		"Aphid" 3


### PR DESCRIPTION
fleets.txt contains a wrong spelled ship name in Line 709.
This PR fixes that.